### PR TITLE
Fix CoreSimulator hang with timeout and pre-flight checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,9 @@ This is a fork of Facebook's idb (iOS Development Bridge) maintained for the [ar
 - Custom packaging and static linking modifications
 - Versioned releases for reproducible builds
 - No dependency on user/system installations
+- CoreSimulator compatibility fixes for Xcode 16+
+
+**Important**: This is the arkavo-org fork (github.com/arkavo-org/idb), not the upstream Facebook repository. All PRs should be created against arkavo-org/idb.
 
 ## Project Overview
 
@@ -184,3 +187,7 @@ dist/
 - Use `install_name_tool` to fix framework rpaths if needed
 - Ensure frameworks are codesigned for distribution
 - Check with `otool -L` that all dependencies are resolved
+
+## Development Guidelines
+
+- do not use conventional commits


### PR DESCRIPTION
## Summary
- Adds 15s timeout to all FBFuture operations to prevent indefinite hangs
- Adds pre-flight check to detect empty CoreSimulator device sets
- Improves error handling to distinguish between timeout and device not found errors

## Problem
The library was hanging indefinitely when CoreSimulator returned empty device sets, particularly on fresh Xcode installations where no simulators have been booted yet. The hang occurred inside `FBIDBWait awaitFuture:` calls with no timeout.

## Solution
1. Created a `FBIDBWaitWithTimeout` wrapper function that uses FBFuture's built-in `awaitWithTimeout:error:` method
2. Added pre-flight check in simulator connection to detect empty device sets early
3. Enhanced error handling to return proper error codes (IDB_ERROR_TIMEOUT vs IDB_ERROR_DEVICE_NOT_FOUND)
4. Added logging for better debugging of CoreSimulator API issues

## Test plan
- [x] Build library with changes
- [ ] Test with empty CoreSimulator (no booted devices)
- [ ] Test with booted simulator
- [ ] Verify timeout occurs after 15s on hanging operations
- [ ] Verify proper error codes are returned

🤖 Generated with [Claude Code](https://claude.ai/code)